### PR TITLE
Making geoip2.reader service public

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -2,6 +2,7 @@ services:
     geoip2.reader:
         class: GeoIp2\Database\Reader
         arguments: [ '%geoip2.cache%', '%geoip2.locales%' ]
+        public: true
 
     gpslab.command.geoip2.update:
         class: GpsLab\Bundle\GeoIP2Bundle\Command\UpdateDatabaseCommand


### PR DESCRIPTION
This is necessary to make it work with Symfony 4. Because in Symfony 4 all services are private by default, so this service cannot be used by default.