### PR TITLE
1.1.1: Making geoip2.reader service work with Symfony 4.2

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -14,6 +14,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    const ROOT_NODE =   'gpslab_geoip';
+
     /**
      * Config tree builder.
      *
@@ -28,8 +30,17 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        return (new TreeBuilder())
-            ->root('gpslab_geoip')
+        $treeBuilder = new TreeBuilder(static::ROOT_NODE);
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            // Symfony 4.2 +
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // Symfony 4.1 and below
+            $rootNode = $treeBuilder->root(static::ROOT_NODE);
+        }
+        return
+            $rootNode
                 ->children()
                     ->scalarNode('cache')
                         ->cannotBeEmpty()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -39,6 +39,7 @@ class Configuration implements ConfigurationInterface
             // Symfony 4.1 and below
             $rootNode = $treeBuilder->root(static::ROOT_NODE);
         }
+
         return
             $rootNode
                 ->children()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -14,7 +14,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    const ROOT_NODE =   'gpslab_geoip';
+    const ROOT_NODE = 'gpslab_geoip';
 
     /**
      * Config tree builder.


### PR DESCRIPTION
This is necessary because Symfony 4.2 has deprecated the use of Treebuilder without a root node:
"A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0."

The idea for the fix was borrowed from here:
https://github.com/sensiolabs/SensioFrameworkExtraBundle/issues/593