### PR TITLE
New Symfony 4 bin/composer directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,19 @@ Add to your `composer.json` event callbacks in a `scripts` section:
 }
 ```
 
+**Symfony >4 Flex**
+
+Add the command "geoip2:update": "symfony-cmd" to your autoscripts
+
+```json
+{
+    "scripts": {
+        "auto-scripts": {
+              "geoip2:update": "symfony-cmd""
+        },
+    }
+}
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Add the command "geoip2:update": "symfony-cmd" to your autoscripts
 {
     "scripts": {
         "auto-scripts": {
-              "geoip2:update": "symfony-cmd""
+              "geoip2:update": "symfony-cmd"
         },
     }
 }

--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -22,6 +22,7 @@ class ScriptHandler
      */
     private static $options = [
         'symfony-app-dir' => 'app',
+        'symfony-bin-dir' => 'bin
     ];
 
     /**
@@ -151,7 +152,7 @@ class ScriptHandler
      */
     private static function useNewDirectoryStructure(array $options)
     {
-        return isset($options['symfony-var-dir']) && is_dir($options['symfony-var-dir']);
+        return isset($options['symfony-bin-dir']) && is_dir($options['symfony-bin-dir']);
     }
 
     /**

--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -22,7 +22,7 @@ class ScriptHandler
      */
     private static $options = [
         'symfony-app-dir' => 'app',
-        'symfony-bin-dir' => 'bin
+        'symfony-bin-dir' => 'bin'
     ];
 
     /**

--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -21,8 +21,7 @@ class ScriptHandler
      * to forthcoming listeners.
      */
     private static $options = [
-        'symfony-app-dir' => 'app',
-        'symfony-bin-dir' => 'bin'
+        'symfony-app-dir' => 'app' 
     ];
 
     /**


### PR DESCRIPTION
Hi thanks for this helpful bundle. The update script anticipates the need to use 'bin' rather than 'app' but the method useNewDirectoryStructure is looking for symfony-var-dir option.  I added the symfony-bin-dir directory as an explicit option and the useNewDirectoryStructure method to look for that.  I think this will help keep the script working with projects independent of 'symfony-var-dir' .  Thanks!