### PR TITLE
Remove gpslab/compressor

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,0 +1,21 @@
+UPGRADE FROM 1.x to 2.0
+=======================
+
+### Dependencies
+
+ * The `UpdateDatabaseCommand` command not dependency a `CompressorInterface`.
+
+### Renamed services
+
+ * The `gpslab.command.geoip2.update` renamed to `GpsLab\Bundle\GeoIP2Bundle\Command\UpdateDatabaseCommand`.
+
+### Removed service
+
+ * The `gpslab.geoip2.component.gzip` service removed.
+
+Updating Dependencies
+---------------------
+
+### Removed package
+
+ * The `gpslab/compressor` package removed from dependencies.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "ext-phar": "*",
         "php": ">=5.4.0",
         "geoip2/geoip2": "~2.0",
-        "gpslab/compressor": "~1.0",
         "symfony/stopwatch": "~2.3|~3.0|~4.0"
     },
     "require-dev": {

--- a/src/Command/UpdateDatabaseCommand.php
+++ b/src/Command/UpdateDatabaseCommand.php
@@ -9,7 +9,6 @@
 
 namespace GpsLab\Bundle\GeoIP2Bundle\Command;
 
-use GpsLab\Component\Compressor\CompressorInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -44,11 +43,10 @@ class UpdateDatabaseCommand extends Command
     /**
      * @param Filesystem $fs
      * @param Stopwatch $stopwatch
-     * @param CompressorInterface $compressor
      * @param string $url
      * @param string $cache
      */
-    public function __construct(Filesystem $fs, Stopwatch $stopwatch, CompressorInterface $compressor, $url, $cache)
+    public function __construct(Filesystem $fs, Stopwatch $stopwatch, $url, $cache)
     {
         $this->fs = $fs;
         $this->url = $url;

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -4,13 +4,8 @@ services:
         arguments: [ '%geoip2.cache%', '%geoip2.locales%' ]
         public: true
 
-    gpslab.command.geoip2.update:
-        class: GpsLab\Bundle\GeoIP2Bundle\Command\UpdateDatabaseCommand
-        arguments: [ '@filesystem', '@debug.stopwatch', '@gpslab.geoip2.component.gzip', '%geoip2.url%', '%geoip2.cache%' ]
+    GpsLab\Bundle\GeoIP2Bundle\Command\UpdateDatabaseCommand:
+        arguments: [ '@filesystem', '@debug.stopwatch', '%geoip2.url%', '%geoip2.cache%' ]
+        public: false
         tags:
             - { name: console.command }
-
-    # use this service only in this bundle
-    gpslab.geoip2.component.gzip:
-        class: GpsLab\Component\Compressor\GzipCompressor
-        public: false


### PR DESCRIPTION
The method of decompress the GeoIp database has been changed in #19 and now a `gpslab/compressor` is no longer needed. Remove it.