### PR TITLE
Not use Stopwatch

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,10 +1,6 @@
 UPGRADE FROM 1.x to 2.0
 =======================
 
-### Dependencies
-
- * The `UpdateDatabaseCommand` command not dependency a `CompressorInterface`.
-
 ### Renamed services
 
  * The `gpslab.command.geoip2.update` renamed to `GpsLab\Bundle\GeoIP2Bundle\Command\UpdateDatabaseCommand`.
@@ -19,3 +15,4 @@ Updating Dependencies
 ### Removed package
 
  * The `gpslab/compressor` package removed from dependencies.
+ * The `symfony/stopwatch` package removed from dependencies.

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
     "require": {
         "ext-phar": "*",
         "php": ">=7.1.0",
-        "geoip2/geoip2": "~2.0",
-        "symfony/stopwatch": "~2.3|~3.0|~4.0"
+        "geoip2/geoip2": "~2.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",

--- a/src/Command/UpdateDatabaseCommand.php
+++ b/src/Command/UpdateDatabaseCommand.php
@@ -15,16 +15,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Stopwatch\Stopwatch;
-use Symfony\Component\Stopwatch\StopwatchEvent;
 
 class UpdateDatabaseCommand extends Command
 {
-    /**
-     * @var Stopwatch
-     */
-    private $stopwatch;
-
     /**
      * @var Filesystem
      */
@@ -42,20 +35,17 @@ class UpdateDatabaseCommand extends Command
 
     /**
      * @param Filesystem $fs
-     * @param Stopwatch $stopwatch
      * @param string $url
      * @param string $cache
      */
     public function __construct(
         Filesystem $fs,
-        Stopwatch $stopwatch,
         string $url,
         string $cache
     ) {
         $this->fs = $fs;
         $this->url = $url;
         $this->cache = $cache;
-        $this->stopwatch = $stopwatch;
         parent::__construct();
     }
 
@@ -92,7 +82,6 @@ class UpdateDatabaseCommand extends Command
         $target = $input->getArgument('target');
 
         $io->title('Update the GeoIP2 database');
-        $this->stopwatch->start('update');
 
         $tmp_zip = sys_get_temp_dir().'/GeoLite2.tar.gz';
         $tmp_unzip = sys_get_temp_dir().'/GeoLite2.tar';
@@ -166,20 +155,6 @@ class UpdateDatabaseCommand extends Command
 
         $io->success('Finished downloading');
 
-        $this->stopwatch($io, $this->stopwatch->stop('update'));
-
         return 0;
-    }
-
-    /**
-     * @param SymfonyStyle $io
-     * @param StopwatchEvent $event
-     */
-    private function stopwatch(SymfonyStyle $io, StopwatchEvent $event): void
-    {
-        $io->writeln([
-            sprintf('Time: <info>%.2F</info> s.', $event->getDuration() / 1000),
-            sprintf('Memory: <info>%.2F</info> MiB.', $event->getMemory() / 1024 / 1024),
-        ]);
     }
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -5,7 +5,7 @@ services:
         public: true
 
     GpsLab\Bundle\GeoIP2Bundle\Command\UpdateDatabaseCommand:
-        arguments: [ '@filesystem', '@debug.stopwatch', '%geoip2.url%', '%geoip2.cache%' ]
+        arguments: [ '@filesystem', '%geoip2.url%', '%geoip2.cache%' ]
         public: false
         tags:
             - { name: console.command }


### PR DESCRIPTION
[Stopwatch](https://symfony.com/doc/current/components/stopwatch.html) used to debug performance.
This is not required to update the GeoIP database.
Remove non-cretical dependence.