### PR TITLE
Сomposer is not used anymore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "symfony/dependency-injection": "~2.3|~3.0|~4.0",
         "symfony/expression-language": "~2.3|~3.0|~4.0",
         "symfony/console": "~2.3|~3.0|~4.0",
-        "composer/composer" : "~1.3",
         "phpunit/phpunit": "~7.0|~8.0",
         "scrutinizer/ocular": "~1.3",
         "satooshi/php-coveralls": "^1.0"


### PR DESCRIPTION
Composer was used for ScriptHandler which was removed in #26, so it not needed anymore. Remove it