### PR TITLE
Not use ArrayNodeDefinition::cannotBeEmpty()

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -250,7 +250,7 @@ class Configuration implements ConfigurationInterface
         $locales->prototype('scalar');
         $locales
             ->treatNullLike([])
-            ->cannotBeEmpty()
+            ->requiresAtLeastOneElement()
             ->defaultValue(['en']);
 
         $database_node->children()->scalarNode('license');


### PR DESCRIPTION
Fix deprecation error
> Using `Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition::cannotBeEmpty()` at path `gpslab_geoip.databases..locales` has no effect, con
sider `requiresAtLeastOneElement()` instead. In 4.0 both methods will behave the same.