### PR TITLE
Run test by PHPStan in Travis CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ before_script:
 script:
     - php php-cs-fixer fix --diff --dry-run -v
     - vendor/bin/phpunit --coverage-clover build/coverage-clover.xml
+    - vendor/phpstan/phpstan/phpstan analyse
 
 after_script:
     - php ocular.phar code-coverage:upload --format=php-clover build/coverage-clover.xml

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,8 +7,9 @@ parameters:
     paths:
         - src
         - tests
+    excludes_analyse:
+        # heavily dependent on the version of Symfony
+        - src/DependencyInjection/Configuration
     ignoreErrors:
-        # error in Symfony 4.1 and below
-        - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder::root\(\)\.#'
         # error in PHPStan because Phar::decompress() return Phar #37
         - '#Call to an undefined method object::extractTo\(\)#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,4 +8,7 @@ parameters:
         - src
         - tests
     ignoreErrors:
+        # error in Symfony 4.1 and below
         - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder::root\(\)\.#'
+        # error in PHPStan because Phar::decompress() return Phar #37
+        - '#Call to an undefined method object::extractTo\(\)#'


### PR DESCRIPTION
Run test by PHPStan in Travis CI jobs.
Ignore error of `Phar::decompress()` in PHPStan #37
Exclude `Configuration` class from analyse because it is highly dependent on the version of Symfony.

### Symfony 2.3 - 3.4

  Line   | src/DependencyInjection/Configuration.php
 ------ | -------------------------------------------------
  42     | Class `Symfony\Component\Config\Definition\Builder\TreeBuilder` does not have a constructor and must be instantiated without any parameters.
  188    | Class `Symfony\Component\Config\Definition\Builder\TreeBuilder` does not have a constructor and must be instantiated without any parameters.

### Symfony 4.0 - 4.4

  Line  | src/DependencyInjection/Configuration.php
 ------ | ----------------------------
  165   | Call to an undefined method `Symfony\Component\Config\Definition\Builder\NodeDefinition::fixXmlConfig()`.
  166    | Call to an undefined method `Symfony\Component\Config\Definition\Builder\NodeDefinition::children()`.
  172    | Call to an undefined method `Symfony\Component\Config\Definition\Builder\NodeDefinition::children()`.
  174    | Call to an undefined method `Symfony\Component\Config\Definition\Builder\NodeDefinition::children()`.
  177    | Call to an undefined method `Symfony\Component\Config\Definition\Builder\NodeDefinition::fixXmlConfig()`.
  178    | Call to an undefined method `Symfony\Component\Config\Definition\Builder\NodeDefinition::append()`.
  199    | Call to an undefined method `Symfony\Component\Config\Definition\Builder\NodeDefinition::requiresAtLeastOneElement()`.
  259    | Method `GpsLab\Bundle\GeoIP2Bundle\DependencyInjection\Configuration::getDatabaseNode()` should return `Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition` but returns `Symfony\Component\Config\Definition\Builder\NodeDefinition`.

### Symfony 5.0

  Line   | src/DependencyInjection/Configuration.php
 ------ | -------------------------------------------------
  49     | Call to an undefined method `Symfony\Component\Config\Definition\Builder\TreeBuilder::root()`.
  195    | Call to an undefined method `Symfony\Component\Config\Definition\Builder\TreeBuilder::root()`.
