### PR TITLE
Fix PHP version badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Latest Stable Version](https://img.shields.io/packagist/v/gpslab/geoip2.svg?maxAge=3600&label=stable)](https://packagist.org/packages/gpslab/geoip2)
-[![PHP from Travis config](https://img.shields.io/travis/php-v/gpslab/geoip2.svg?maxAge=3600)](https://packagist.org/packages/gpslab/geoip2)
+[![PHP from Packagist](https://img.shields.io/packagist/php-v/gpslab/geoip2?maxAge=3600)](https://packagist.org/packages/gpslab/geoip2)
 [![Build Status](https://img.shields.io/travis/gpslab/geoip2.svg?maxAge=3600)](https://travis-ci.org/gpslab/geoip2)
 [![Coverage Status](https://img.shields.io/coveralls/gpslab/geoip2.svg?maxAge=3600)](https://coveralls.io/github/gpslab/geoip2?branch=master)
 [![Scrutinizer Code Quality](https://img.shields.io/scrutinizer/g/gpslab/geoip2.svg?maxAge=3600)](https://scrutinizer-ci.com/g/gpslab/geoip2/?branch=master)


### PR DESCRIPTION
PHP version badge from Travis config is broken.

![PHP from Travis config](https://img.shields.io/travis/php-v/gpslab/geoip2.svg)
![PHP from Travis config](https://user-images.githubusercontent.com/1954436/73957555-90c31180-4917-11ea-958d-a7de99c2da27.png)

Use **PHP from Packagist** instead.
https://shields.io/category/platform-support