### PR TITLE
Badge "PHP from Travis config" works again

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Latest Stable Version](https://img.shields.io/packagist/v/gpslab/geoip2.svg?maxAge=3600&label=stable)](https://packagist.org/packages/gpslab/geoip2)
-[![PHP from Packagist](https://img.shields.io/packagist/php-v/gpslab/geoip2?maxAge=3600)](https://packagist.org/packages/gpslab/geoip2)
+[![PHP from Travis config](https://img.shields.io/travis/php-v/gpslab/geoip2?maxAge=3600)](https://packagist.org/packages/gpslab/geoip2)
 [![Build Status](https://img.shields.io/travis/gpslab/geoip2.svg?maxAge=3600)](https://travis-ci.org/gpslab/geoip2)
 [![Coverage Status](https://img.shields.io/coveralls/gpslab/geoip2.svg?maxAge=3600)](https://coveralls.io/github/gpslab/geoip2?branch=master)
 [![Scrutinizer Code Quality](https://img.shields.io/scrutinizer/g/gpslab/geoip2.svg?maxAge=3600)](https://scrutinizer-ci.com/g/gpslab/geoip2/?branch=master)


### PR DESCRIPTION
Badge "PHP from Travis config" works again
https://shields.io/category/platform-support
![image](https://user-images.githubusercontent.com/1954436/74047379-4ad28000-49e1-11ea-81f4-964be95267c0.png)
![PHP from Travis config](https://img.shields.io/travis/php-v/gpslab/geoip2)
