### PR TITLE
Fix tests for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 phpunit.xml
 composer.lock
 .php_cs.cache
+.phpunit.result.cache

--- a/tests/DependencyInjection/GpsLabGeoIP2ExtensionTest.php
+++ b/tests/DependencyInjection/GpsLabGeoIP2ExtensionTest.php
@@ -115,7 +115,7 @@ class GpsLabGeoIP2ExtensionTest extends TestCase
             $this->assertTrue($reader->isPublic());
             $this->assertTrue($reader->isLazy());
             $this->assertSame(Reader::class, $reader->getClass());
-            $path = sprintf('%s/%s.mmdb', $cache_dir ?: '/tmp', $database['edition']);
+            $path = sprintf('%s/%s.mmdb', $cache_dir ?: sys_get_temp_dir(), $database['edition']);
             $this->assertSame($path, $reader->getArgument(0));
             $this->assertSame($database['locales'] ?? ['en'], $reader->getArgument(1));
 

--- a/tests/Downloader/MaxMindDownloaderTest.php
+++ b/tests/Downloader/MaxMindDownloaderTest.php
@@ -56,12 +56,14 @@ class MaxMindDownloaderTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Not found GeoLite2 database in archive.');
 
+        $path = sys_get_temp_dir();
+        $path_quote = preg_quote($path, '#');
         $url = 'https://example.com';
-        $target = sprintf('%s/%s_GeoLite2.mmdb', sys_get_temp_dir(), uniqid('', true));
+        $target = sprintf('%s/%s_GeoLite2.mmdb', $path, uniqid('', true));
 
-        $tmp_zip_regexp = sprintf('#^%s/[\da-f]+\.\d+_GeoLite2\.tar\.gz$#', sys_get_temp_dir());
-        $tmp_unzip_regexp = sprintf('#^%s/[\da-f]+\.\d+_GeoLite2\.tar$#', sys_get_temp_dir());
-        $tmp_untar_regexp = sprintf('#^%s/[\da-f]+\.\d+_GeoLite2$#', sys_get_temp_dir());
+        $tmp_zip_regexp = sprintf('#^%s/[\da-f]+\.\d+_GeoLite2\.tar\.gz$#', $path_quote);
+        $tmp_unzip_regexp = sprintf('#^%s/[\da-f]+\.\d+_GeoLite2\.tar$#', $path_quote);
+        $tmp_untar_regexp = sprintf('#^%s/[\da-f]+\.\d+_GeoLite2$#', $path_quote);
 
         $this->logger
             ->expects($this->atLeastOnce())
@@ -109,12 +111,14 @@ class MaxMindDownloaderTest extends TestCase
 
     public function testDownload(): void
     {
+        $path = sys_get_temp_dir();
+        $path_quote = preg_quote($path, '#');
         $url = 'https://example.com';
-        $target = sprintf('%s/%s_GeoLite2.mmdb', sys_get_temp_dir(), uniqid('', true));
+        $target = sprintf('%s/%s_GeoLite2.mmdb', $path, uniqid('', true));
 
-        $tmp_zip_regexp = sprintf('#^%s/[\da-f]+\.\d+_GeoLite2\.tar\.gz$#', sys_get_temp_dir());
-        $tmp_unzip_regexp = sprintf('#^%s/[\da-f]+\.\d+_GeoLite2\.tar$#', sys_get_temp_dir());
-        $tmp_untar_regexp = sprintf('#^%s/[\da-f]+\.\d+_GeoLite2$#', sys_get_temp_dir());
+        $tmp_zip_regexp = sprintf('#^%s/[\da-f]+\.\d+_GeoLite2\.tar\.gz$#', $path_quote);
+        $tmp_unzip_regexp = sprintf('#^%s/[\da-f]+\.\d+_GeoLite2\.tar$#', $path_quote);
+        $tmp_untar_regexp = sprintf('#^%s/[\da-f]+\.\d+_GeoLite2$#', $path_quote);
 
         $this->logger
             ->expects($this->atLeastOnce())
@@ -159,13 +163,17 @@ class MaxMindDownloaderTest extends TestCase
         $this->fs
             ->expects($this->at($fs_call++))
             ->method('copy')
-            ->willReturnCallback(function ($origin_file, $target_file, $overwrite_newer_files) use ($target) {
+            ->willReturnCallback(function (
+                $origin_file,
+                $target_file,
+                $overwrite_newer_files
+            ) use ($target, $path_quote) {
                 $this->assertIsString($origin_file);
                 $this->assertSame($target, $target_file);
                 $this->assertTrue($overwrite_newer_files);
                 $regexp = sprintf(
                     '#^%s/[\da-f]+\.\d+_GeoLite2/GeoLite2-City_20200114/GeoLite2.mmdb$#',
-                    sys_get_temp_dir()
+                    $path_quote
                 );
                 $this->assertRegExp($regexp, $origin_file);
                 $this->assertFileExists($origin_file);


### PR DESCRIPTION
```
1) GpsLab\Bundle\GeoIP2Bundle\Tests\DependencyInjection\GpsLabGeoIP2ExtensionTest::testLoad with data set #0 (null)
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'/tmp/GeoLite2-ASN.mmdb'
+'C:\Users\PGRIBA~1\AppData\Local\Temp/GeoLite2-ASN.mmdb'

2) GpsLab\Bundle\GeoIP2Bundle\Tests\DependencyInjection\GpsLabGeoIP2ExtensionTest::testLoad with data set #2 (false)
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'/tmp/GeoLite2-ASN.mmdb'
+'C:\Users\PGRIBA~1\AppData\Local\Temp/GeoLite2-ASN.mmdb'

3) GpsLab\Bundle\GeoIP2Bundle\Tests\Downloader\MaxMindDownloaderTest::testNotFoundDatabase
Failed asserting that 'C:\Users\PGRIBA~1\AppData\Local\Temp/5e7b08f99e6b23.65897103_GeoLite2.tar.gz' matches PCRE pattern "#^C:\Users\PGRIBA~1\AppData\Local\Temp/[\da-f]+\.\d+_GeoLite2\.tar\.gz$#".

4) GpsLab\Bundle\GeoIP2Bundle\Tests\Downloader\MaxMindDownloaderTest::testDownload
Failed asserting that 'C:\Users\PGRIBA~1\AppData\Local\Temp/5e7b08f9a228b2.61970509_GeoLite2.tar.gz' matches PCRE pattern "#^C:\Users\PGRIBA~1\AppData\Local\Temp/[\da-f]+\.\d+_GeoLite2\.tar\.gz$#".
```