### PR TITLE
Correct rules in Style CI config

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -8,4 +8,3 @@ disabled:
   - phpdoc_align
   - yoda_style
   - blank_line_after_opening_tag
-  - phpdoc_no_empty_return

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,7 +1,6 @@
 preset: symfony
 
 enabled:
-  - short_array_syntax
   - alpha_ordered_imports
 
 disabled:


### PR DESCRIPTION
Fix errors in Style CI

> Config Issue
> The 'phpdoc_no_empty_return' fixer cannot be disabled because it is not enabled by your preset.
> The 'short_array_syntax' fixer cannot be enabled again because it has already been enabled.