### PR TITLE
Disable no_superfluous_phpdoc_tags_symfony Style CI rule

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -7,3 +7,4 @@ disabled:
   - phpdoc_align
   - yoda_style
   - blank_line_after_opening_tag
+  - no_superfluous_phpdoc_tags_symfony


### PR DESCRIPTION
Disable [`no_superfluous_phpdoc_tags_symfony`](https://docs.styleci.io/fixers#no_superfluous_phpdoc_tags_symfony) Style CI rule.