### PR TITLE
Build from GitHub CI

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -1,0 +1,59 @@
+name: Quality assurance
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install PHP with extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.1
+          coverage: none
+          tools: composer:v2
+
+      - name: Install variant
+        run: |
+          composer require phpstan/phpstan:"0.11.*" --no-update
+          composer require phpstan/phpstan-phpunit:"0.11.*" --no-update
+
+      - name: Install Composer dependencies (highest)
+        uses: 'ramsey/composer-install@v1'
+        with:
+          dependency-versions: 'highest'
+          composer-options: '--prefer-dist --prefer-stable'
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan --memory-limit=1G analyse
+
+  php-cs-fixer:
+    name: PHP CS Fixer
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install PHP with extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.1
+          coverage: none
+          tools: composer:v2 cs2pr, php-cs-fixer
+
+      - name: Install Composer dependencies (highest)
+        uses: 'ramsey/composer-install@v1'
+        with:
+          dependency-versions: 'highest'
+          composer-options: '--prefer-dist --prefer-stable'
+
+      - name: Run PHP-CS-Fixer
+        run: php-cs-fixer fix --dry-run --format checkstyle | cs2pr

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,73 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: 'PHP ${{ matrix.php-version }} + ${{ matrix.dependencies }} + ${{ matrix.variant }}'
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        dependencies:
+          - lowest
+          - highest
+        php-version:
+          - '7.1'
+          - '7.2'
+          - '7.3'
+          - '7.4'
+        experimental: [false]
+        variant: [normal]
+        include:
+#          - php-version: '7.1'
+#            dependencies: highest
+#            allowed-to-fail: false
+#            variant: 'symfony/symfony:"2.8.*"'
+#          - php-version: '7.1'
+#            dependencies: highest
+#            allowed-to-fail: false
+#            variant: 'symfony/symfony:"3.0.*"'
+          - php-version: '8.0'
+            dependencies: highest
+            variant: normal
+            experimental: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install PHP with extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          tools: composer:v2
+
+      - name: Install variant
+        if: matrix.variant != 'normal'
+        run: composer require ${{ matrix.variant }} --no-update
+
+      - name: 'Install Composer dependencies (${{ matrix.dependencies }})'
+        uses: 'ramsey/composer-install@v1'
+        with:
+          dependency-versions: '${{ matrix.dependencies }}'
+          composer-options: '--prefer-dist --prefer-stable'
+
+      - name: Run Tests
+        run: vendor/bin/phpunit --coverage-clover build/coverage-clover.xml
+
+      - name: Send coverage results to Scrutinizer CI
+        run: |
+          wget https://scrutinizer-ci.com/ocular.phar
+          php ocular.phar code-coverage:upload --format=php-clover build/coverage-clover.xml
+
+      - name: Send coverage results to Coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_PARALLEL: true
+          COVERALLS_FLAG_NAME: 'PHP ${{ matrix.php-version }} + ${{ matrix.dependencies }} + ${{ matrix.variant }}'
+        run: |
+          composer global require php-coveralls/php-coveralls
+          php-coveralls -x build/coverage-clover.xml -o build/coveralls-upload.json -v


### PR DESCRIPTION
Travis CI takes a very long time to build. Building and testing just one commit can take up to 16 hours. It looks like this problem is related to the migration of https://travis-ci.org to https://travis-ci.com. The https://travis-ci.org domain will be closed later than December 31st, 2020.