### PR TITLE
Reduce memory usage of geoip2:update

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,13 @@ You can update several databases:
 php bin/console geoip2:update city country
 ```
 
+Optionally installing splitbrain/php-archive uses significantly less memory when updating a database
+and can avoid out of memory errors:
+
+```
+composer req splitbrain/php-archive
+```
+
 ### Download GeoIP database
 
 You can download custom database with console command:

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "ext-zlib": "*",
         "php": ">=7.1.0",
         "geoip2/geoip2": "~2.0",
+        "splitbrain/php-archive": "~1.2",
         "symfony/http-kernel": "~2.8|~3.0|~4.0|~5.0",
         "symfony/dependency-injection": "~2.8|~3.0|~4.0|~5.0",
         "symfony/expression-language": "~2.8|~3.0|~4.0|~5.0",

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,8 @@
         "phpunit/phpunit": "~7.0|~8.0|~9.0",
         "phpstan/phpstan": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12"
+    },
+    "suggest": {
+        "splitbrain/php-archive": "Greatly reduces memory usage for the geoip2:update command"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         "ext-zlib": "*",
         "php": ">=7.1.0",
         "geoip2/geoip2": "~2.0",
-        "splitbrain/php-archive": "~1.2",
         "symfony/http-kernel": "~2.8|~3.0|~4.0|~5.0",
         "symfony/dependency-injection": "~2.8|~3.0|~4.0|~5.0",
         "symfony/expression-language": "~2.8|~3.0|~4.0|~5.0",

--- a/src/Downloader/MaxMindDownloader.php
+++ b/src/Downloader/MaxMindDownloader.php
@@ -67,7 +67,7 @@ class MaxMindDownloader implements Downloader
         $this->fs->copy($url, $tmp_zip, true);
 
         $this->logger->debug(sprintf('Download complete to %s', $tmp_zip));
-        $this->logger->debug(sprintf('Extracting archive file to %s', $tmp_zip));
+        $this->logger->debug(sprintf('Extracting archive file to %s', $tmp_untar));
 
         $this->fs->mkdir(dirname($target), 0755);
 
@@ -84,7 +84,10 @@ class MaxMindDownloader implements Downloader
         $database = '';
         $files = glob(sprintf('%s/**/*.mmdb', $tmp_untar)) ?: [];
         foreach ($files as $file) {
-            // expected something like that "GeoLite2-City_20200114"
+            // Use any .mmdb file in the archive, but stop searching if one matches the format expected below
+            $database = $file;
+
+            // expected filename like "GeoLite2-City_YYYYMMDD"
             if (preg_match('/(?<database>[^\/]+)_(?<year>\d{4})(?<month>\d{2})(?<day>\d{2})/', $file, $match)) {
                 $this->logger->debug(sprintf(
                     'Found %s database updated at %s-%s-%s in %s',
@@ -94,9 +97,8 @@ class MaxMindDownloader implements Downloader
                     $match['day'],
                     $file
                 ));
+                break;
             }
-
-            $database = $file;
         }
 
         if (!$database) {


### PR DESCRIPTION
Using \PharData to extract the database file causes an out of memory exception since July 22 for the GeoLite2-City database when using the default 128MB memory_limit on Fedora and other distributions.  Use splitbrain/php-archive to reduce memory usage from 147MB to 18MB.  

Solves https://github.com/gpslab/geoip2/issues/82