### PR TITLE
Do not download when licence is not set

### DIFF
--- a/src/Command/UpdateDatabaseCommand.php
+++ b/src/Command/UpdateDatabaseCommand.php
@@ -116,12 +116,11 @@ EOT;
             $io->section(sprintf('Update "%s" database', $database));
 
             if (empty($this->databases[$database]['license'])) {
-                $io->warning(sprintf('`GeoIP Database %s has no maxmind license key', $database));
+                $io->warning(sprintf('GeoIP Database %s has no maxmind license key', $database));
             } else {
                 $this->downloader->download($this->databases[$database]['url'], $this->databases[$database]['path']);
+                $io->comment(sprintf('Database <info>%s</info> updated', $database));
             }
-
-            $io->comment(sprintf('Database <info>%s</info> updated', $database));
         }
 
         $io->success('Finished updating');

--- a/src/Command/UpdateDatabaseCommand.php
+++ b/src/Command/UpdateDatabaseCommand.php
@@ -115,7 +115,11 @@ EOT;
 
             $io->section(sprintf('Update "%s" database', $database));
 
-            $this->downloader->download($this->databases[$database]['url'], $this->databases[$database]['path']);
+            if (empty($this->databases[$database]['license'])) {
+                $io->warning(sprintf('`GeoIP Database %s has no maxmind license key', $database));
+            } else {
+                $this->downloader->download($this->databases[$database]['url'], $this->databases[$database]['path']);
+            }
 
             $io->comment(sprintf('Database <info>%s</info> updated', $database));
         }

--- a/tests/Command/UpdateDatabaseCommandTest.php
+++ b/tests/Command/UpdateDatabaseCommandTest.php
@@ -190,6 +190,28 @@ class UpdateDatabaseCommandTest extends TestCase
         $command->run($this->input, $this->output);
     }
 
+    public function testDownloadWithoutLicense(): void
+    {
+        $this->input
+            ->expects($this->at(4))
+            ->method('getArgument')
+            ->with('databases')
+            ->willReturn(['default']);
+
+        $databases = ['default' => [
+            'url' => 'https://example.com/GeoIP2.tar.gz',
+            'path' => '/tmp/GeoIP2.mmdb',
+        ]];
+
+        $this->downloader
+            ->expects($this->never())
+            ->method('download')
+            ->with($databases['default']['url'], $databases['default']['path']);
+
+        $command = new UpdateDatabaseCommand($this->downloader, $databases);
+        $command->run($this->input, $this->output);
+    }
+
     public function testDownloadOneDatabases(): void
     {
         $this->input
@@ -201,6 +223,7 @@ class UpdateDatabaseCommandTest extends TestCase
         $databases = ['default' => [
             'url' => 'https://example.com/GeoIP2.tar.gz',
             'path' => '/tmp/GeoIP2.mmdb',
+            'license' => 'license',
         ]];
 
         $this->downloader
@@ -224,10 +247,12 @@ class UpdateDatabaseCommandTest extends TestCase
             'first' => [
                 'url' => 'https://example.com/GeoIP2-First.tar.gz',
                 'path' => '/tmp/GeoIP2-First.mmdb',
+                'license' => 'license',
             ],
             'second' => [
                 'url' => 'https://example.com/GeoIP2-Second.tar.gz',
                 'path' => '/tmp/GeoIP2-Second.mmdb',
+                'license' => 'license',
             ],
         ];
 


### PR DESCRIPTION
I needed the bundle not fail in the command because a license has not been set
for my project there are use cases where a license will not be used (its up to the user)
this pr will instead of blindly try a download show a warning when the license is not set and skip the download step.