### PR TITLE
Fix a deprecation

### DIFF
--- a/src/DependencyInjection/GpsLabGeoIP2Extension.php
+++ b/src/DependencyInjection/GpsLabGeoIP2Extension.php
@@ -20,7 +20,7 @@ use GpsLab\Bundle\GeoIP2Bundle\Reader\ReaderFactory;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 class GpsLabGeoIP2Extension extends Extension
 {


### PR DESCRIPTION
The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "GpsLab\Bundle\GeoIP2Bundle\DependencyInjection\GpsLabGeoIP2Extension".